### PR TITLE
Update action-pack.js

### DIFF
--- a/module/action-pack.js
+++ b/module/action-pack.js
@@ -87,7 +87,7 @@ Hooks.on("updateItem", (item) => {
 });
 
 Hooks.on("updateCombat", (combat) => {
-    currentlyActiveActor = combat.turns.find(c => c.id == combat.current.combatantId).actor
+    currentlyActiveActor = combat.turns.find(c => c.id == combat.current.combatantId)?.actor
     updateCombatStatus();
     lastKnownActiveActor = currentlyActiveActor;
 });


### PR DESCRIPTION
missing optional chaining operator. error comes up if you try to start/delete a combat with no combatants.