### PR TITLE
Support custom character sheet sections

### DIFF
--- a/module/action-pack.js
+++ b/module/action-pack.js
@@ -421,7 +421,15 @@ async function updateTray() {
 
             const hasUses = settingShowNoUses || !uses || uses.available;
 
+            const customSectionName = item.flags['custom-character-sheet-sections']?.sectionName;
+
             if (hasUses && itemData.activation?.type && itemData.activation.type !== "none" && !item.getFlag("action-pack", "hidden")) {
+                if (customSectionName) {
+                    ensureCustomSectionExists(sections, item);
+                    sections.custom[customSectionName.slugify()].items.push({ item, uses });
+                    continue;
+                }
+
                 switch (item.type) {
                 case "feat":
                     const type = item.system.type.value;
@@ -483,6 +491,17 @@ async function updateTray() {
                 }
             } else if (actor.type === "npc") {
                 sections.passive.items.push({ item, uses });
+            }
+        }
+
+        function ensureCustomSectionExists(sections, item) {
+            const customSectionName = item.flags['custom-character-sheet-sections']?.sectionName;
+            const customSectionSlug = customSectionName.slugify();
+            if (!sections.hasOwnProperty("custom")) {
+                sections.custom = {};
+            }
+            if (!sections.custom.hasOwnProperty(customSectionSlug)) {
+                sections.custom[customSectionSlug] = { items: [], title: customSectionName };
             }
         }
 

--- a/templates/action-pack.hbs
+++ b/templates/action-pack.hbs
@@ -147,6 +147,11 @@
                     {{#with spell}}
                         {{> item-category showSpellDots=../../../showSpellDots}}
                     {{/with}}
+                    {{#each custom}}
+                    {{#with this}}
+                        {{> item-category}}
+                    {{/with}}
+                    {{/each}}
                     {{#with inventory}}
                         {{> item-category}}
                     {{/with}}


### PR DESCRIPTION
Add support for custom sections provided by the module [Custom Character Sheet Sections](https://github.com/jessev14/custom-character-sheet-sections). I have placed the custom sections after "Spells" and before "Inventory".

The custom sections are used regularly by [DDB Importer](https://github.com/MrPrimate/ddb-importer) and [Chris's Premades](https://github.com/chrisk123999/chris-premades) as well as other modules.

![image](https://github.com/teroparvinen/foundry-action-pack/assets/293277/99883271-10a1-453a-b266-3d5d75cc049a)
