### PR TITLE
Add an Option to display Legendary Actions as Point per Max instead of uses.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -73,6 +73,7 @@
             "tray-size-large": "Large",
             "use-control-button": "Include a toggle button in token controls",
             "show-no-uses": "Show items with no uses left",
+            "show-la-as-la-uses": "Show legendary actions as the action amount and not uses.",
             "sort-alphabetic": "Sort items alphabetically",
             "show-unprepared-cantrips": "Show cantrips even if they are not prepared",
             "show-spell-dots": "Show spell slot dots",

--- a/module/action-pack.js
+++ b/module/action-pack.js
@@ -257,6 +257,19 @@ Hooks.on("init", () => {
   
     game.settings.register(
         "action-pack",
+        "show-la-as-la-uses",
+        {
+            name: "action-pack.settings.show-la-as-la-uses",
+            scope: "client",
+            config: true,
+            default: false,
+            type: Boolean,
+            onChange: () => updateTray()
+        }
+    );
+  
+    game.settings.register(
+        "action-pack",
         "sort-alphabetic",
         {
             name: "action-pack.settings.sort-alphabetic",

--- a/module/item-uses.js
+++ b/module/item-uses.js
@@ -29,9 +29,18 @@ export const calculateUsesForItem = (item) => {
 function calculateConsumeUses(actor, consume) {
     let available = null;
     let maximum = null;
+	
+	let settingLegendActUses = game.settings.get("action-pack", "show-la-as-la-uses");
+	
     if (consume.type === 'attribute') {
+		
         const value = getProperty(actor.system, consume.target);
-        if (typeof value === 'number') {
+		if(consume.target === 'resources.legact.value' & settingLegendActUses){
+			//return {1,999};
+			available = Math.floor(consume.amount);
+			maximum = Math.floor(actor.system.resources.legact.value);
+			return { available, maximum };
+		}else if (typeof value === 'number') {
             available = value;
         } else {
             available = 0;


### PR DESCRIPTION
For Legendary Action, seeing the needed points and the maximum is better in my opinion than the available uses.
This is kinda ugly so feel free to tweak it but i think this is better for this since multiple items use the same pool of points here.